### PR TITLE
Bindings for `argon2_core'.

### DIFF
--- a/src/argon2/__init__.py
+++ b/src/argon2/__init__.py
@@ -13,6 +13,7 @@ from ._api import (
     hash_password,
     hash_password_raw,
     verify_password,
+    core,
 )
 from ._password_hasher import PasswordHasher
 
@@ -42,4 +43,5 @@ __all__ = [
     "hash_password",
     "hash_password_raw",
     "verify_password",
+    "core",
 ]

--- a/src/argon2/_api.py
+++ b/src/argon2/_api.py
@@ -19,6 +19,7 @@ __all__ = [
     "hash_password",
     "hash_password_raw",
     "verify_password",
+    "core",
 ]
 
 DEFAULT_RANDOM_SALT_LENGTH = 16
@@ -26,7 +27,6 @@ DEFAULT_HASH_LENGTH = 16
 DEFAULT_TIME_COST = 2
 DEFAULT_MEMORY_COST = 512
 DEFAULT_PARALLELISM = 2
-
 
 def hash_password(password, salt=None,
                   time_cost=DEFAULT_TIME_COST,
@@ -132,3 +132,72 @@ def verify_password(hash, password, type=Type.I):
         return True
     else:
         raise VerificationError(_error_to_str(rv))
+
+def core(password,
+         salt=None,
+         secret=None,
+         associated_data=None,
+         time_cost=DEFAULT_TIME_COST,
+         memory_cost=DEFAULT_MEMORY_COST,
+         parallelism=DEFAULT_PARALLELISM,
+         threads=None,
+         hash_len=DEFAULT_HASH_LENGTH,
+         type=Type.I):
+    """
+    Performs the core argon2 key-derivation.
+
+        This function takes the same parameters as :func:`hash_password`
+            and additionally the optional arguments
+
+        :param bytes secret:
+        :param bytes associated_data:
+        :param int threads: actual maximum number of threads to spawn
+        :rtype: bool
+    """
+    # Check parameters
+    if salt is None:
+        salt = os.urandom(DEFAULT_RANDOM_SALT_LENGTH)
+    if threads is None:
+        threads = parallelism
+
+    out_buf = ffi.new('char[]', hash_len)
+    salt_buf = ffi.new('char[]', salt)
+
+    # Set up context
+    context = ffi.new('argon2_context *')
+    context.out = out_buf
+    context.outlen = hash_len
+    context.pwd = ffi.new('char[]', password)
+    context.pwdlen = len(password)
+    context.salt = salt_buf
+    context.saltlen = len(salt)
+    context.t_cost = time_cost
+    context.m_cost = memory_cost
+    context.lanes = parallelism
+    context.threads = threads
+    context.allocate_cbk = ffi.NULL
+    context.free_cbk = ffi.NULL
+    context.flags = 4 # XXX
+
+    if secret is None:
+        context.secret = ffi.NULL
+        context.secretlen = 0
+    else:
+        secretbuf = ffi.new('char[]', secret)
+        context.secret = secretbuf
+        context.secretlen = len(secret)
+
+    if associated_data is None:
+        context.ad = ffi.NULL
+        context.adlen = 0
+    else:
+        adbuf = ffi.new('char[]', associated_data)
+        context.ad = adbuf
+        context.adlen = len(associated_data)
+
+    # Run!
+    rv = lib.argon2_core(context, type.value)
+    if rv != lib.ARGON2_OK:
+        raise HashingError(_error_to_str(rv))
+
+    return bytes(ffi.buffer(out_buf))

--- a/src/argon2/_api.py
+++ b/src/argon2/_api.py
@@ -28,6 +28,7 @@ DEFAULT_TIME_COST = 2
 DEFAULT_MEMORY_COST = 512
 DEFAULT_PARALLELISM = 2
 
+
 def hash_password(password, salt=None,
                   time_cost=DEFAULT_TIME_COST,
                   memory_cost=DEFAULT_MEMORY_COST,
@@ -133,6 +134,7 @@ def verify_password(hash, password, type=Type.I):
     else:
         raise VerificationError(_error_to_str(rv))
 
+
 def core(password,
          salt=None,
          secret=None,
@@ -177,7 +179,7 @@ def core(password,
     context.threads = threads
     context.allocate_cbk = ffi.NULL
     context.free_cbk = ffi.NULL
-    context.flags = 4 # XXX
+    context.flags = 4  # XXX
 
     if secret is None:
         context.secret = ffi.NULL

--- a/src/argon2/_ffi_build.py
+++ b/src/argon2/_ffi_build.py
@@ -34,6 +34,9 @@ ffi.set_source(
 ffi.cdef("""\
 typedef enum Argon2_type { Argon2_d = 0, Argon2_i = 1 } argon2_type;
 
+typedef int (*allocate_fptr)(uint8_t **memory, size_t bytes_to_allocate);
+typedef void (*deallocate_fptr)(uint8_t *memory, size_t bytes_to_allocate);
+
 int argon2_hash(const uint32_t t_cost, const uint32_t m_cost,
                 const uint32_t parallelism, const void *pwd,
                 const size_t pwdlen, const void *salt, const size_t saltlen,
@@ -103,6 +106,36 @@ typedef enum Argon2_ErrorCodes {
                                  this
                                  error code */
 } argon2_error_codes;
+
+typedef struct Argon2_Context {
+    uint8_t *out;    /* output array */
+    uint32_t outlen; /* digest length */
+
+    uint8_t *pwd;    /* password array */
+    uint32_t pwdlen; /* password length */
+
+    uint8_t *salt;    /* salt array */
+    uint32_t saltlen; /* salt length */
+
+    uint8_t *secret;    /* key array */
+    uint32_t secretlen; /* key length */
+
+    uint8_t *ad;    /* associated data array */
+    uint32_t adlen; /* associated data length */
+
+    uint32_t t_cost;  /* number of passes */
+    uint32_t m_cost;  /* amount of memory requested (KB) */
+    uint32_t lanes;   /* number of lanes */
+    uint32_t threads; /* maximum number of threads */
+
+    allocate_fptr allocate_cbk; /* pointer to memory allocator */
+    deallocate_fptr free_cbk;   /* pointer to memory deallocator */
+
+    uint32_t flags; /* array of bool options */
+} argon2_context;
+
+int argon2_core(argon2_context *context, argon2_type type);
+
 """)
 
 if __name__ == '__main__':

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -217,4 +217,3 @@ class TestCore(object):
         rv = core(b"abc\x00", TEST_SALT)
 
         assert rv != core(b"abc", TEST_SALT)
-

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from argon2 import (
-    hash_password, hash_password_raw, verify_password, Type,
+    hash_password, hash_password_raw, verify_password, Type, core,
     DEFAULT_RANDOM_SALT_LENGTH,
 )
 from argon2.exceptions import VerificationError, HashingError
@@ -186,3 +186,35 @@ class TestVerify(object):
         """
         with pytest.raises(TypeError):
             verify_password(TEST_HASH_I, TEST_PASSWORD.decode("ascii"))
+
+
+class TestCore(object):
+    @i_and_d_raw
+    def test_hash_password_raw(self, type, hash):
+        """
+        Creates the same raw hash as the Argon2 CLI client.
+        """
+        rv = core(
+            TEST_PASSWORD,
+            TEST_SALT,
+            None,
+            None,
+            TEST_TIME,
+            TEST_MEMORY,
+            TEST_PARALLELISM,
+            None,
+            TEST_HASH_LEN,
+            type,
+        )
+
+        assert hash == rv
+        assert isinstance(rv, bytes)
+
+    def test_hash_nul_bytes(self):
+        """
+        Hashing passwords with NUL bytes works as expected.
+        """
+        rv = core(b"abc\x00", TEST_SALT)
+
+        assert rv != core(b"abc", TEST_SALT)
+


### PR DESCRIPTION
At the moment, only `argon2_hash` and `argon2_hash_raw` are bound.  These do not allow one to specify *secret*, *associated data* or *maximum number of threads*.  This PR adds a binding for `argon2_core`, which takes the missing arguments.