### PR TITLE
low_level: fix missing encoding line

### DIFF
--- a/src/argon2/low_level.py
+++ b/src/argon2/low_level.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Low-level functions if you want to build your own higher level abstractions.
 

--- a/src/argon2/low_level.py
+++ b/src/argon2/low_level.py
@@ -4,7 +4,7 @@ Low-level functions if you want to build your own higher level abstractions.
 
 .. warning::
     This is a "Hazardous Materials" module.  You should **ONLY** use it if
-    you’re 100% absolutely sure that you know what you’re doing because this
+    you're 100% absolutely sure that you know what you’re doing because this
     module is full of land mines, dragons, and dinosaurs with laser guns.
 """
 


### PR DESCRIPTION
Without this:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "argon2/__init__.py", line 5, in <module>
    from . import exceptions, low_level
  File "argon2/low_level.py", line 6
SyntaxError: Non-ASCII character '\xe2' in file argon2/low_level.py on line 7, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```