### PR TITLE
Fix "invalid escape sequence" warnings in Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ LONG = (
     read("README.rst") + "\n\n" +
     "Release Information\n" +
     "===================\n\n" +
-    re.search("(\d+.\d.\d \(.*?\)\n.*?)\n\n\n----\n\n\n",
+    re.search(r"(\d+.\d.\d \(.*?\)\n.*?)\n\n\n----\n\n\n",
               read("CHANGELOG.rst"), re.S).group(1) +
     "\n\n`Full changelog " +
     "<{uri}en/stable/changelog.html>`_.\n\n".format(uri=URI) +

--- a/src/argon2/_password_hasher.py
+++ b/src/argon2/_password_hasher.py
@@ -27,7 +27,7 @@ def _ensure_bytes(s, encoding):
 
 
 class PasswordHasher(object):
-    """
+    r"""
     High level class to hash passwords with sensible defaults.
 
     Uses *always* Argon2\ **i** and a random salt_.

--- a/src/argon2/low_level.py
+++ b/src/argon2/low_level.py
@@ -41,13 +41,13 @@ class Type(Enum):
     Enum of Argon2 variants.
     """
     D = lib.Argon2_d
-    """
+    r"""
     Argon2\ **d** is faster and uses data-depending memory access, which makes
     it less suitable for hashing secrets and more suitable for cryptocurrencies
     and applications with no threats from side-channel timing attacks.
     """
     I = lib.Argon2_i
-    """
+    r"""
     Argon2\ **i** uses data-independent memory access, which is preferred for
     password hashing and password-based key derivation.  Argon2i is slower as
     it makes more passes over the memory to protect from tradeoff attacks.


### PR DESCRIPTION
http://bugs.python.org/issue27364
