### PR TITLE
add pypy3 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
       env: TOXENV=py35
     - python: "pypy"
       env: TOXENV=pypy
+    - python: pypy3.3-5.2-alpha1
+          env: TOXENV=pypy3
 
     # Meta
     - python: "3.5"
@@ -38,7 +40,7 @@ install:
         pyenv install pypy-5.4.1
         pyenv global pypy-5.4.1
     fi
-  - pip install tox
+  - pip install tox-travis
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - python: "pypy"
       env: TOXENV=pypy
     - python: pypy3.3-5.2-alpha1
-          env: TOXENV=pypy3
+      env: TOXENV=pypy3
 
     # Meta
     - python: "3.5"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 passenv = TERM  # ensure colors
-envlist = py27,py34,py35,pypy,docs,flake8,manifest,readme,coverage-report
+envlist = py27,py34,py35,pypy,pypy3,docs,flake8,manifest,readme,coverage-report
 
 
 [testenv]


### PR DESCRIPTION
I changed tox install to tox-travis because they worked out a fix https://github.com/ryanhiebert/tox-travis/pull/24 . Everything works the same.